### PR TITLE
Add Cloudflare env vars support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # Log level for the application (optional)
 # Options: debug, info, warn, error
 VITE_LOG_LEVEL=debug
+
+# Cloudflare credentials (optional)
+CLOUDFLARE_API_KEY=your_cloudflare_api_key_here
+CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id_here

--- a/scripts/cleanup-workers.ts.old
+++ b/scripts/cleanup-workers.ts.old
@@ -87,7 +87,7 @@ async function deactivateWorker(apiToken: string, accountId: string, worker: Wor
 }
 
 async function main() {
-  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_API_KEY;
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 
   // Only manage these specific workers

--- a/scripts/list-workers.ts.old
+++ b/scripts/list-workers.ts.old
@@ -11,7 +11,7 @@ interface Worker {
 }
 
 async function main() {
-  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_API_KEY;
   const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 
   if (!apiToken || !accountId) {


### PR DESCRIPTION
## Summary
- document Cloudflare credentials in `.env.example`
- allow `CLOUDFLARE_API_KEY` as a fallback for scripts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68888a7f9604832c97af24cdebdde3fe