### PR TITLE
Update repo branding for Deep Tree Echo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for reporting an issue :pray:.
 
-        This issue tracker is for bugs and issues found with [Bolt.new](https://bolt.new).
+        This issue tracker is for bugs and issues found with **Deep Tree Echo**.
         If you experience issues related to WebContainer, please file an issue in our [WebContainer repo](https://github.com/stackblitz/webcontainer-core), or file an issue in our [StackBlitz core repo](https://github.com/stackblitz/core) for issues with StackBlitz.
 
         The more information you fill in, the better we can help you.
@@ -20,7 +20,7 @@ body:
   - type: input
     id: link
     attributes:
-      label: Link to the Bolt URL that caused the error
+      label: Link to the Deep Tree Echo URL that caused the error
       description: Please do not delete it after reporting!
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bolt.new Help Center
+  - name: Deep Tree Echo Help Center
     url: https://support.bolt.new
-    about: Official central repository for tips, tricks, tutorials, known issues, and best practices for bolt.new usage.
+    about: Official repository for tips, tricks, tutorials, known issues, and best practices for Deep Tree Echo.
   - name: Billing Issues
     url: https://support.bolt.new/Billing-13fd971055d680ebb393cb80973710b6
     about: Instructions for billing and subscription related support
   - name: Discord Chat
     url: https://discord.gg/stackblitz
-    about: Build, share, and learn with other Bolters in real time.
+    about: Build, share, and learn with other community members in real time.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm run lint
 
       - name: Wrangler Deploy
-        run: wrangler pages deploy ./build/client --project-name bolt-echo
+        run: wrangler pages deploy ./build/client --project-name deep-tree-echo
 
 #  build:
 #    runs-on: ...

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,6 @@ jobs:
 
       # Step 5: Deploy to Cloudflare Pages
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy ./build/client --project-name bolt-echo
+        run: npx wrangler pages deploy ./build/client --project-name deep-tree-echo
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -55,4 +55,4 @@ jobs:
 
       # Step 5: Deploy to Pages
       - name: Deploy to Cloudflare Pages
-        run: wrangler pages deploy ./build/client --project-name bolt-echo
+        run: wrangler pages deploy ./build/client --project-name deep-tree-echo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,14 +35,14 @@ jobs:
           
       - name: Deploy to Staging
         if: github.event_name == 'pull_request'
-        run: wrangler pages deploy ./build/client --project-name bolt-echo
+        run: wrangler pages deploy ./build/client --project-name deep-tree-echo
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           
       - name: Deploy to Production
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: wrangler pages deploy ./build/client --project-name bolt-echo
+        run: wrangler pages deploy ./build/client --project-name deep-tree-echo
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/wrangler-deploy-pages.yml
+++ b/.github/workflows/wrangler-deploy-pages.yml
@@ -44,4 +44,4 @@ jobs:
 
       # Step 6: Deploy to Cloudflare Pages
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy ./build/client --project-name bolt-echo
+        run: npx wrangler pages deploy ./build/client --project-name deep-tree-echo

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 
-# Bolt.new: AI-Powered Full-Stack Web Development in the Browser
+# Deep Tree Echo
 
-[![Bolt.new: AI-Powered Full-Stack Web Development in the Browser](./public/social_preview_index.jpg)](https://bolt.new)
+[![Deep Tree Echo](./public/social_preview_index.jpg)](https://bolt.new)
 
-Bolt.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered web dev agent using the Bolt open source codebase, [click here to get started!](./CONTRIBUTING.md)
+Deep Tree Echo is an AI-powered agent built on the open-source Bolt framework. It allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered dev agent using the Bolt codebase, [click here to get started!](./CONTRIBUTING.md)
 
-## What Makes Bolt.new Different
+## What Makes Deep Tree Echo Different
 
-Claude, v0, etc are incredible- but you can't install packages, run backends or edit code. That’s where Bolt.new stands out:
+Claude, v0, etc are incredible—but you can't install packages, run backends or edit code. That's where Deep Tree Echo stands out:
 
-- **Full-Stack in the Browser**: Bolt.new integrates cutting-edge AI models with an in-browser development environment powered by **StackBlitz’s WebContainers**. This allows you to:
+- **Full-Stack in the Browser**: Deep Tree Echo integrates cutting-edge AI models with an in-browser development environment powered by **StackBlitz’s WebContainers**. This allows you to:
   - Install and run npm tools and libraries (like Vite, Next.js, and more)
   - Run Node.js servers
   - Interact with third-party APIs
   - Deploy to production from chat
   - Share your work via a URL
 
-- **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Bolt.new gives AI models **complete control** over the entire  environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
+- **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Deep Tree Echo gives AI models **complete control** over the entire environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
 
-Whether you’re an experienced developer, a PM or designer, Bolt.new allows you to build production-grade full-stack applications with ease.
+Whether you're an experienced developer, a PM or designer, Deep Tree Echo allows you to build production-grade full-stack applications with ease.
 
 For developers interested in building their own AI-powered development tools with WebContainers, check out the open-source Bolt codebase in this repo!
 
 ## Tips and Tricks
 
-Here are some tips to get the most out of Bolt.new:
+Here are some tips to get the most out of Deep Tree Echo:
 
 - **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
 
@@ -37,19 +37,19 @@ Here are some tips to get the most out of Bolt.new:
 ## FAQs
 
 **Where do I sign up for a paid plan?**  
-Bolt.new is free to get started. If you need more AI tokens or want private projects, you can purchase a paid subscription in your [Bolt.new](https://bolt.new) settings, in the lower-left hand corner of the application.
+Deep Tree Echo is free to get started. If you need more AI tokens or want private projects, you can purchase a paid subscription in your [Bolt.new](https://bolt.new) settings, in the lower-left-hand corner of the application.
 
 **What happens if I hit the free usage limit?**  
 Once your free daily token limit is reached, AI interactions are paused until the next day or until you upgrade your plan.
 
-**Is Bolt in beta?**  
-Yes, Bolt.new is in beta, and we are actively improving it based on feedback.
+**Is Deep Tree Echo in beta?**
+Yes, Deep Tree Echo is in beta, and we are actively improving it based on feedback.
 
-**How can I report Bolt.new issues?**  
+**How can I report Deep Tree Echo issues?**
 Check out the [Issues section](https://github.com/stackblitz/bolt.new/issues) to report an issue or request a new feature. Please use the search feature to check if someone else has already submitted the same issue/request.
 
-**What frameworks/libraries currently work on Bolt?**  
-Bolt.new supports most popular JavaScript frameworks and libraries. If it runs on StackBlitz, it will run on Bolt.new as well.
+**What frameworks/libraries currently work on Deep Tree Echo?**
+Deep Tree Echo supports most popular JavaScript frameworks and libraries. If it runs on StackBlitz, it will run on Deep Tree Echo as well.
 
-**How can I add make sure my framework/project works well in bolt?**  
-We are excited to work with the JavaScript ecosystem to improve functionality in Bolt. Reach out to us via [hello@stackblitz.com](mailto:hello@stackblitz.com) to discuss how we can partner!
+**How can I make sure my framework or project works well in Deep Tree Echo?**
+We are excited to work with the JavaScript ecosystem to improve functionality in Deep Tree Echo. Reach out to us via [hello@stackblitz.com](mailto:hello@stackblitz.com) to discuss how we can partner!

--- a/package.build.json
+++ b/package.build.json
@@ -19,6 +19,6 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "remix vite:build && npx wrangler pages deploy ./build/client --project-name bolt-echo"
+    "build": "remix vite:build && npx wrangler pages deploy ./build/client --project-name deep-tree-echo"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "type": "module",
     "scripts": {
-        "deploy": "pnpm run build:pages && npx wrangler pages deploy build/client --project-name bolt-echo",
+        "deploy": "pnpm run build:pages && npx wrangler pages deploy build/client --project-name deep-tree-echo",
         "build": "remix vite:build --force",
         "build:pages": "./build-pages.sh",
         "dev": "remix vite:dev",

--- a/scripts/cleanup-workers.ts.old
+++ b/scripts/cleanup-workers.ts.old
@@ -92,16 +92,16 @@ async function main() {
 
   // Only manage these specific workers
   const boltEchoWorkers = [
-    'bolt-echo',           // Main deployment
-    'bolt-echo-tail',      // Tail deployment
+    'deep-tree-echo',      // Main deployment
+    'deep-tree-echo-tail', // Tail deployment
     'marduk-bolt',         // Marduk integration
     'bolt-cog'            // Cog deployment
   ];
 
   // Define which ones to keep active
   const keepActiveWorkers = [
-    'bolt-echo',           // Main production worker
-    'bolt-echo-staging',   // Staging environment
+    'deep-tree-echo',           // Main production worker
+    'deep-tree-echo-staging',   // Staging environment
     'marduk-bolt',         // Keep Marduk integration
     'bolt-cog'            // Keep Cog deployment
   ];

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
-name = "boltecho"
+name = "deep-tree-echo"
 compatibility_date = "2024-07-18"
 compatibility_flags = ["nodejs_compat"]
 
 [env.production]
-name = "boltecho"
+name = "deep-tree-echo"

--- a/wrangler.toml.backup
+++ b/wrangler.toml.backup
@@ -1,6 +1,6 @@
-name = "bolt-echo"
+name = "deep-tree-echo"
 compatibility_date = "2024-07-18"
 compatibility_flags = ["nodejs_compat"]
 
 [env.production]
-name = "bolt-echo"
+name = "deep-tree-echo"


### PR DESCRIPTION
## Summary
- update README with Deep Tree Echo branding
- update issue templates and config links
- rename Cloudflare deployment project to `deep-tree-echo`
- adjust workflow files and scripts

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 25620 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68889057fad8832ca62399cf11ed8f71