### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wrangler-deploy-pages.yml
+++ b/.github/workflows/wrangler-deploy-pages.yml
@@ -6,6 +6,9 @@ on:
       - main # Deploy when changes are pushed to the main branch
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy Pages and Worker


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/bolt.echo/security/code-scanning/22](https://github.com/EchoCog/bolt.echo/security/code-scanning/22)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and deploying to Cloudflare Pages, we will set `contents: read` as the minimal required permission. This ensures the workflow has only the permissions it needs to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is appropriate because the workflow contains only one job (`deploy`), and no other jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
