### PR TITLE
Fix cloudflare deployment

### DIFF
--- a/.cloudflare/pages.json
+++ b/.cloudflare/pages.json
@@ -1,7 +1,7 @@
 {
   "buildCommand": "cd .cloudflare && npm run build",
   "outputDirectory": "build/client",
-  "nodeVersion": "18.18.0",
+  "nodeVersion": "20.15.1",
   "installCommand": "cd .cloudflare && npm install",
   "framework": "remix"
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,7 @@ name = "boltecho"
 compatibility_date = "2024-07-18"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "build/client"
+main = "worker.js"
 
 [build]
 command = "pnpm run build:pages"


### PR DESCRIPTION
Fix Cloudflare deployment by specifying the worker entry point and updating the Node.js version.

Cloudflare's build was failing because Wrangler could not find a Worker entry point. Adding `main = "worker.js"` to `wrangler.toml` resolves this. Additionally, the Node.js version in `.cloudflare/pages.json` was updated to match the project's requirements, ensuring consistent build environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1d1313b-f199-45c9-9e10-a67702f86bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1d1313b-f199-45c9-9e10-a67702f86bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>