### PR TITLE
Fix app ui for radix dark mode

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -64,7 +64,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
         ref={ref}
         className={classNames(
           styles.BaseChat,
-          'relative flex h-full w-full overflow-hidden bg-bolt-elements-background-depth-1',
+          'relative flex h-full w-full overflow-hidden bg-bolt-elements-bg-depth-1',
         )}
         data-chat-visible={showChat}
       >
@@ -181,7 +181,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                     ) : null}
                   </div>
                 </div>
-                <div className="bg-bolt-elements-background-depth-1 pb-6">{/* Ghost Element */}</div>
+                <div className="bg-bolt-elements-bg-depth-1 pb-6">{/* Ghost Element */}</div>
               </div>
             </div>
             {!chatStarted && (

--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -11,7 +11,7 @@ export function Header() {
   return (
     <header
       className={classNames(
-        'flex items-center bg-bolt-elements-background-depth-1 p-5 border-b h-[var(--header-height)]',
+        'flex items-center bg-bolt-elements-bg-depth-1 p-5 border-b h-[var(--header-height)]',
         {
           'border-transparent': !chat.started,
           'border-bolt-elements-borderColor': chat.started,

--- a/app/components/sidebar/HistoryItem.tsx
+++ b/app/components/sidebar/HistoryItem.tsx
@@ -38,7 +38,7 @@ export function HistoryItem({ item, onDelete }: HistoryItemProps) {
   return (
     <div
       ref={hoverRef}
-      className="group rounded-md text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary hover:bg-bolt-elements-background-depth-3 overflow-hidden flex justify-between items-center px-2 py-1"
+              className="group rounded-md text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary hover:bg-bolt-elements-bg-depth-3 overflow-hidden flex justify-between items-center px-2 py-1"
     >
       <a href={`/chat/${item.urlId}`} className="flex w-full relative truncate block">
         {item.description}

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -104,7 +104,7 @@ export function Menu() {
       initial="closed"
       animate={open ? 'open' : 'closed'}
       variants={menuVariants}
-      className="flex flex-col side-menu fixed top-0 w-[350px] h-full bg-bolt-elements-background-depth-2 border-r rounded-r-3xl border-bolt-elements-borderColor z-sidebar shadow-xl shadow-bolt-elements-sidebar-dropdownShadow text-sm"
+              className="flex flex-col side-menu fixed top-0 w-[350px] h-full bg-bolt-elements-bg-depth-2 border-r rounded-r-3xl border-bolt-elements-borderColor z-sidebar shadow-xl shadow-bolt-elements-sidebar-dropdownShadow text-sm"
     >
       <div className="flex items-center h-[var(--header-height)]">{/* Placeholder */}</div>
       <div className="flex-1 flex flex-col h-full w-full overflow-hidden">
@@ -123,7 +123,7 @@ export function Menu() {
           <DialogRoot open={dialogContent !== null}>
             {binDates(list).map(({ category, items }) => (
               <div key={category} className="mt-4 first:mt-0 space-y-1">
-                <div className="text-bolt-elements-textTertiary sticky top-0 z-1 bg-bolt-elements-background-depth-2 pl-2 pt-2 pb-1">
+                <div className="text-bolt-elements-textTertiary sticky top-0 z-1 bg-bolt-elements-bg-depth-2 pl-2 pt-2 pb-1">
                   {category}
                 </div>
                 {items.map((item) => (
@@ -143,7 +143,7 @@ export function Menu() {
                       <p className="mt-1">Are you sure you want to delete this chat?</p>
                     </div>
                   </DialogDescription>
-                  <div className="px-5 pb-4 bg-bolt-elements-background-depth-2 flex gap-2 justify-end">
+                  <div className="px-5 pb-4 bg-bolt-elements-bg-depth-2 flex gap-2 justify-end">
                     <DialogButton type="secondary" onClick={closeDialog}>
                       Cancel
                     </DialogButton>

--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -114,7 +114,7 @@ export const Dialog = memo(({ className, children, onBackdrop, onClose }: Dialog
       <RadixDialog.Content asChild>
         <motion.div
           className={classNames(
-            'fixed top-[50%] left-[50%] z-max max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] border border-bolt-elements-borderColor rounded-lg bg-bolt-elements-background-depth-2 shadow-lg focus:outline-none overflow-hidden',
+            'fixed top-[50%] left-[50%] z-max max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] border border-bolt-elements-borderColor rounded-lg bg-bolt-elements-bg-depth-2 shadow-lg focus:outline-none overflow-hidden',
             className,
           )}
           initial="closed"

--- a/app/components/ui/PanelHeader.tsx
+++ b/app/components/ui/PanelHeader.tsx
@@ -10,7 +10,7 @@ export const PanelHeader = memo(({ className, children }: PanelHeaderProps) => {
   return (
     <div
       className={classNames(
-        'flex items-center gap-2 bg-bolt-elements-background-depth-2 text-bolt-elements-textSecondary border-b border-bolt-elements-borderColor px-4 py-1 min-h-[34px] text-sm',
+        'flex items-center gap-2 bg-bolt-elements-bg-depth-2 text-bolt-elements-textSecondary border-b border-bolt-elements-borderColor px-4 py-1 min-h-[34px] text-sm',
         className,
       )}
     >

--- a/app/components/ui/Slider.tsx
+++ b/app/components/ui/Slider.tsx
@@ -24,7 +24,7 @@ export const Slider = genericMemo(<T,>({ selected, options, setSelected }: Slide
   const isLeftSelected = selected === options.left.value;
 
   return (
-    <div className="flex items-center flex-wrap shrink-0 gap-1 bg-bolt-elements-background-depth-1 overflow-hidden rounded-full p-1">
+          <div className="flex items-center flex-wrap shrink-0 gap-1 bg-bolt-elements-bg-depth-1 overflow-hidden rounded-full p-1">
       <SliderButton selected={isLeftSelected} setSelected={() => setSelected?.(options.left.value)}>
         {options.left.text}
       </SliderButton>

--- a/app/components/workbench/EditorPanel.tsx
+++ b/app/components/workbench/EditorPanel.tsx
@@ -198,7 +198,7 @@ export const EditorPanel = memo(
         >
           <div className="h-full">
             <div className="bg-bolt-elements-terminals-background h-full flex flex-col">
-              <div className="flex items-center bg-bolt-elements-background-depth-2 border-y border-bolt-elements-borderColor gap-1.5 min-h-[34px] p-2">
+              <div className="flex items-center bg-bolt-elements-bg-depth-2 border-y border-bolt-elements-borderColor gap-1.5 min-h-[34px] p-2">
                 {Array.from({ length: terminalCount }, (_, index) => {
                   const isActive = activeTerminal === index;
 
@@ -209,7 +209,7 @@ export const EditorPanel = memo(
                         'flex items-center text-sm cursor-pointer gap-1.5 px-3 py-2 h-full whitespace-nowrap rounded-full',
                         {
                           'bg-bolt-elements-terminals-buttonBackground text-bolt-elements-textPrimary': isActive,
-                          'bg-bolt-elements-background-depth-2 text-bolt-elements-textSecondary hover:bg-bolt-elements-terminals-buttonBackground':
+                          'bg-bolt-elements-bg-depth-2 text-bolt-elements-textSecondary hover:bg-bolt-elements-terminals-buttonBackground':
                             !isActive,
                         },
                       )}

--- a/app/components/workbench/FileBreadcrumb.tsx
+++ b/app/components/workbench/FileBreadcrumb.tsx
@@ -118,7 +118,7 @@ export const FileBreadcrumb = memo<FileBreadcrumbProps>(({ files, pathSegments =
                         variants={contextMenuVariants}
                       >
                         <div className="rounded-lg overflow-hidden">
-                          <div className="max-h-[50vh] min-w-[300px] overflow-scroll bg-bolt-elements-background-depth-1 border border-bolt-elements-borderColor shadow-sm rounded-lg">
+                          <div className="max-h-[50vh] min-w-[300px] overflow-scroll bg-bolt-elements-bg-depth-1 border border-bolt-elements-borderColor shadow-sm rounded-lg">
                             <FileTree
                               files={files}
                               hideRoot

--- a/app/components/workbench/PortDropdown.tsx
+++ b/app/components/workbench/PortDropdown.tsx
@@ -50,7 +50,7 @@ export const PortDropdown = memo(
       <div className="relative z-port-dropdown" ref={dropdownRef}>
         <IconButton icon="i-ph:plug" onClick={() => setIsDropdownOpen(!isDropdownOpen)} />
         {isDropdownOpen && (
-          <div className="absolute right-0 mt-2 bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor rounded shadow-sm min-w-[140px] dropdown-animation">
+          <div className="absolute right-0 mt-2 bg-bolt-elements-bg-depth-2 border border-bolt-elements-borderColor rounded shadow-sm min-w-[140px] dropdown-animation">
             <div className="px-4 py-2 border-b border-bolt-elements-borderColor text-sm font-semibold text-bolt-elements-textPrimary">
               Ports
             </div>

--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -77,7 +77,7 @@ export const Preview = memo(() => {
       {isPortDropdownOpen && (
         <div className="z-iframe-overlay w-full h-full absolute" onClick={() => setIsPortDropdownOpen(false)} />
       )}
-      <div className="bg-bolt-elements-background-depth-2 p-2 flex items-center gap-1.5">
+              <div className="bg-bolt-elements-bg-depth-2 p-2 flex items-center gap-1.5">
         <IconButton icon="i-ph:arrow-clockwise" onClick={reloadPreview} />
         <div
           className="flex items-center gap-1 flex-grow bg-bolt-elements-preview-addressBar-background border border-bolt-elements-borderColor text-bolt-elements-preview-addressBar-text rounded-full px-3 py-1 text-sm hover:bg-bolt-elements-preview-addressBar-backgroundHover hover:focus-within:bg-bolt-elements-preview-addressBar-backgroundActive focus-within:bg-bolt-elements-preview-addressBar-backgroundActive

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -117,7 +117,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
           )}
         >
           <div className="absolute inset-0 px-6">
-            <div className="h-full flex flex-col bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor shadow-sm rounded-lg overflow-hidden">
+            <div className="h-full flex flex-col bg-bolt-elements-bg-depth-2 border border-bolt-elements-borderColor shadow-sm rounded-lg overflow-hidden">
               <div className="flex items-center px-3 py-2 border-b border-bolt-elements-borderColor">
                 <Slider selected={selectedView} options={sliderOptions} setSelected={setSelectedView} />
                 <div className="ml-auto" />

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,6 +1,20 @@
 import { RemixBrowser } from '@remix-run/react';
 import { startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
+import { setTheme } from '~/lib/stores/theme';
+
+// Initialize theme on client side
+const initializeTheme = () => {
+  const savedTheme = localStorage.getItem('bolt_theme');
+  const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const theme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+  
+  document.documentElement.setAttribute('data-theme', theme);
+  setTheme(theme);
+};
+
+// Initialize theme before hydration
+initializeTheme();
 
 startTransition(() => {
   hydrateRoot(document.getElementById('root')!, <RemixBrowser />);

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -3,7 +3,6 @@ import { RemixServer } from '@remix-run/react';
 import { isbot } from 'isbot';
 import { renderHeadToString } from 'remix-island';
 import { Head } from './root';
-import { themeStore } from '~/lib/stores/theme';
 import ReactDOMServer from 'react-dom/server';
 
 const { renderToReadableStream } = ReactDOMServer;
@@ -30,7 +29,7 @@ export default async function handleRequest(
       controller.enqueue(
         new Uint8Array(
           new TextEncoder().encode(
-            `<!DOCTYPE html><html lang="en" data-theme="${themeStore.value}"><head>${head}</head><body><div id="root" class="w-full h-full">`,
+            `<!DOCTYPE html><html lang="en" data-theme="light"><head>${head}</head><body><div id="root" class="w-full h-full">`,
           ),
         ),
       );

--- a/app/lib/stores/theme.ts
+++ b/app/lib/stores/theme.ts
@@ -13,11 +13,12 @@ export const DEFAULT_THEME = 'light';
 export const themeStore = atom<Theme>(initStore());
 
 function initStore() {
-  if (!import.meta.env.SSR) {
+  if (typeof window !== 'undefined') {
     const persistedTheme = localStorage.getItem(kTheme) as Theme | undefined;
     const themeAttribute = document.querySelector('html')?.getAttribute('data-theme');
-
-    return persistedTheme ?? (themeAttribute as Theme) ?? DEFAULT_THEME;
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    
+    return persistedTheme ?? (themeAttribute as Theme) ?? (systemPrefersDark ? 'dark' : 'light');
   }
 
   return DEFAULT_THEME;
@@ -29,7 +30,17 @@ export function toggleTheme() {
 
   themeStore.set(newTheme);
 
-  localStorage.setItem(kTheme, newTheme);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(kTheme, newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+  }
+}
 
-  document.querySelector('html')?.setAttribute('data-theme', newTheme);
+export function setTheme(theme: Theme) {
+  themeStore.set(theme);
+  
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(kTheme, theme);
+    document.documentElement.setAttribute('data-theme', theme);
+  }
 }

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -6,6 +6,35 @@ export default defineConfig({
     // add your shortcuts here
   ],
   theme: {
+    colors: {
+      // Ensure theme colors are available
+      'bolt-elements': {
+        'borderColor': 'var(--bolt-elements-borderColor)',
+        'borderColorActive': 'var(--bolt-elements-borderColorActive)',
+        'bg-depth-1': 'var(--bolt-elements-bg-depth-1)',
+        'bg-depth-2': 'var(--bolt-elements-bg-depth-2)',
+        'bg-depth-3': 'var(--bolt-elements-bg-depth-3)',
+        'bg-depth-4': 'var(--bolt-elements-bg-depth-4)',
+        'textPrimary': 'var(--bolt-elements-textPrimary)',
+        'textSecondary': 'var(--bolt-elements-textSecondary)',
+        'textTertiary': 'var(--bolt-elements-textTertiary)',
+        'background-depth-1': 'var(--bolt-elements-bg-depth-1)',
+        'background-depth-2': 'var(--bolt-elements-bg-depth-2)',
+        'background-depth-3': 'var(--bolt-elements-bg-depth-3)',
+        'background-depth-4': 'var(--bolt-elements-bg-depth-4)',
+        'terminals-background': 'var(--bolt-elements-terminals-background)',
+        'terminals-buttonBackground': 'var(--bolt-elements-terminals-buttonBackground)',
+        'preview-addressBar-background': 'var(--bolt-elements-preview-addressBar-background)',
+        'preview-addressBar-backgroundHover': 'var(--bolt-elements-preview-addressBar-backgroundHover)',
+        'preview-addressBar-backgroundActive': 'var(--bolt-elements-preview-addressBar-backgroundActive)',
+        'preview-addressBar-text': 'var(--bolt-elements-preview-addressBar-text)',
+        'preview-addressBar-textActive': 'var(--bolt-elements-preview-addressBar-textActive)',
+        'sidebar-dropdownShadow': 'var(--bolt-elements-sidebar-dropdownShadow)',
+        'sidebar-buttonBackgroundDefault': 'var(--bolt-elements-sidebar-buttonBackgroundDefault)',
+        'sidebar-buttonBackgroundHover': 'var(--bolt-elements-sidebar-buttonBackgroundHover)',
+        'sidebar-buttonText': 'var(--bolt-elements-sidebar-buttonText)',
+      }
+    },
     // add your theme customizations here
   },
   rules: [


### PR DESCRIPTION
Restores Radix dark mode and UI theming by fixing server-side rendering, client-side initialization, and CSS variable inconsistencies.

The previous theme implementation had issues with server-side rendering defaulting to a light theme, incorrect client-side theme initialization timing, and inconsistent CSS variable naming (`background-depth` vs `bg-depth`). This PR resolves these issues to ensure proper system theme detection, user preference persistence, and correct application of themes to all UI components, including Radix UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-4180ff34-5cda-4947-a505-baf278aa3584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4180ff34-5cda-4947-a505-baf278aa3584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

