### PR TITLE
Fix deployment build not allowed for pages

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,9 +6,6 @@ pages_build_output_dir = "build/client"
 [pages]
 output_directory = "build/client"
 
-[build]
-command = "pnpm run build:pages"
-
 [env.production]
 name = "boltecho"
 


### PR DESCRIPTION
Remove `[build]` section from `wrangler.toml` to fix Cloudflare Pages deployment issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3b9f513-3dd3-47cb-8ad6-bbbb1e137a85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3b9f513-3dd3-47cb-8ad6-bbbb1e137a85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

